### PR TITLE
Add GeoJSON validity checking

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,6 +13,7 @@
                 "@openaddresses/batch-error": "^1.1.0",
                 "@openaddresses/batch-generic": "^13.0.1",
                 "@openaddresses/batch-schema": "^7.5.0",
+                "@placemarkio/check-geojson": "^0.1.12",
                 "@tak-ps/blueprint-login": "^0.2.0",
                 "@tak-ps/node-cot": "^2.8.0",
                 "ajv": "^8.11.2",
@@ -1383,6 +1384,14 @@
             },
             "peerDependencies": {
                 "@openaddresses/batch-generic": "x.x.x"
+            }
+        },
+        "node_modules/@placemarkio/check-geojson": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@placemarkio/check-geojson/-/check-geojson-0.1.12.tgz",
+            "integrity": "sha512-sSNPtPDVB0oKwImi4NYg1LVE2QSCIqs/jIRmu8U4fQVWdRjlGy+C/n7AbNO2FycE9rVWtz256f33aMGzvKC7gg==",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@protobufjs/aspromise": {

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
         "@openaddresses/batch-error": "^1.1.0",
         "@openaddresses/batch-generic": "^13.0.1",
         "@openaddresses/batch-schema": "^7.5.0",
+        "@placemarkio/check-geojson": "^0.1.12",
         "@tak-ps/blueprint-login": "^0.2.0",
         "@tak-ps/node-cot": "^2.8.0",
         "ajv": "^8.11.2",

--- a/api/routes/layer.js
+++ b/api/routes/layer.js
@@ -9,7 +9,7 @@ import Auth from '../lib/auth.js';
 import Lambda from '../lib/aws/lambda.js';
 import CloudFormation from '../lib/aws/cloudformation.js';
 import Style from '../lib/style.js';
-import { check } from "@placemarkio/check-geojson"
+import { check } from '@placemarkio/check-geojson';
 
 export default async function router(schema, config) {
     await schema.get('/layer', {

--- a/api/routes/layer.js
+++ b/api/routes/layer.js
@@ -9,6 +9,7 @@ import Auth from '../lib/auth.js';
 import Lambda from '../lib/aws/lambda.js';
 import CloudFormation from '../lib/aws/cloudformation.js';
 import Style from '../lib/style.js';
+import { check } from "@placemarkio/check-geojson"
 
 export default async function router(schema, config) {
     await schema.get('/layer', {
@@ -234,6 +235,13 @@ export default async function router(schema, config) {
             const style = new Style(layer);
 
             if (req.headers['content-type'] === 'application/json') {
+                try {
+                    // https://github.com/placemark/check-geojson/issues/17
+                    req.body = check(JSON.stringify(req.body));
+                } catch (err) {
+                    throw new Err(400, null, err.message);
+                }
+
                 for (const feature of req.body.features) {
                     conn.tak.write(COT.from_geojson(await style.feat(feature)));
                 }


### PR DESCRIPTION
### Context

The ETL server expects GeoJSON features to be posted to the cot route but currently does not check the validity of the GeoJSON. Although layers are inherently trusted sources of data, we should perform validity checking to ensure a developer doesn't accidentally submit a poisoned request body. 