### PR TITLE
Lambda Task Alarms

### DIFF
--- a/api/lib/aws/lambda.js
+++ b/api/lib/aws/lambda.js
@@ -24,6 +24,29 @@ export default class Lambda {
                 }
             },
             Resources: {
+                LambdaAlarm: {
+                    Type: 'AWS::CloudWatch::Alarm',
+                    Properties: {
+                        AlarmName: StackName,
+                        ActionsEnabled: true,
+                        OKActions: [],
+                        AlarmActions: [ `arn:aws:sns:us-east-1:126505572887:${config.StackName}-topic` ],
+                        InsufficientDataActions: [],
+                        MetricName: 'Errors',
+                        Namespace: 'AWS/Lambda',
+                        Statistic: 'Maximum',
+                        Dimensions: [{
+                            Name: 'FunctionName',
+                            Value: StackName
+                        }],
+                        Period: 60,
+                        EvaluationPeriods: 1,
+                        DatapointsToAlarm: 1,
+                        Threshold: 0,
+                        ComparisonOperator: 'GreaterThanThreshold',
+                        TreatMissingData: 'missing'
+                    }
+                },
                 ETLFunctionLogs: {
                     Type: 'AWS::Logs::LogGroup',
                     Properties: {

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -146,7 +146,7 @@ export default {
                                 'cloudwatch:Describe*',
                                 'cloudwatch:Get*',
                                 'cloudwatch:List*',
-                                'cloudwatch:PutMetricAlarm',
+                                'cloudwatch:PutMetricAlarm'
                             ],
                             Resource: [
                                 cf.join(['arn:aws:cloudwatch:', cf.region, ':', cf.accountId, ':alarm:', cf.stackName, '-layer-*'])

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -124,7 +124,7 @@ export default {
                             Resource: [
                                 cf.join(['arn:aws:secretsmanager:', cf.region, ':', cf.accountId, ':secret:', cf.stackName, '/*'])
                             ]
-                        },{
+                        },{ // ------------ Permissions Required to stand up lambda tasks ------------
                             Effect: 'Allow',
                             Action: [
                                 'iam:PassRole'
@@ -139,6 +139,17 @@ export default {
                             ],
                             Resource: [
                                 cf.join(['arn:aws:cloudformation:', cf.region, ':', cf.accountId, ':stack/', cf.stackName, '-layer-*'])
+                            ]
+                        },{
+                            Effect: 'Allow',
+                            Action: [
+                                'cloudwatch:Describe*',
+                                'cloudwatch:Get*',
+                                'cloudwatch:List*',
+                                'cloudwatch:PutMetricAlarm',
+                            ],
+                            Resource: [
+                                cf.join(['arn:aws:cloudwatch:', cf.region, ':', cf.accountId, ':alarm:', cf.stackName, '-layer-*'])
                             ]
                         },{
                             Effect: 'Allow',


### PR DESCRIPTION
### Context

Lambda Tasks currently fail silently and there is no way to determine their state via the ETL UI. This PR introduced a CloudWatch Metric that will be created alongside the lambda and track invocation errors and alarm if there are >0 errors/min.

In a subsequent PR we can then add a `layer.status` prop much like `connection.status` that is populated based on the alarm/not alarm state of this metric. This will in turn allow us to actually use the "green" status icon next to a layer in the same way we have been with connections.
