### PR TITLE
:bug: Ensure Feature is Returned

### DIFF
--- a/api/lib/style.js
+++ b/api/lib/style.js
@@ -22,9 +22,9 @@ export default class Style {
             feature.properties.stale = this.layer.data.stale;
         }
 
-        if (!this.layer.enabled_styles) return feature;
-
-        if (this.layer.styles.queries) {
+        if (!this.layer.enabled_styles) {
+            return feature;
+        } else if (this.layer.styles.queries) {
             for (const q of this.layer.styles.queries) {
                 const expression = jsonata(q.query);
 
@@ -32,8 +32,12 @@ export default class Style {
                     this.#by_geom(feature);
                 }
             }
+
+            return feature;
         } else {
             this.#by_geom(this.layer.styles, feature);
+
+            return feature;
         }
     }
 

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -143,7 +143,7 @@ export default {
                         },{
                             Effect: 'Allow',
                             Action: [
-                                'cloudwatch:Describe*',
+                                'cloudwatch:Describe*'
                             ],
                             Resource: [
                                 cf.join(['arn:aws:cloudwatch:', cf.region, ':', cf.accountId, ':alarm:*'])


### PR DESCRIPTION
### Context

I started playing with the query style API and the layer went into an alarm state (the new alarm code works! :tada:)

Digging in made me realize that although the style API mutates the feature with the correct style properties, it only returns the feature if using the basic style endpoint, resulting in a 5xx error.