### PR TITLE
Basemap Proxy

### DIFF
--- a/api/lib/types/basemap.js
+++ b/api/lib/types/basemap.js
@@ -25,7 +25,7 @@ export default class BaseMap extends Generic {
                 WHERE
                     name ~* ${query.filter}
                 ORDER BY
-                    id DESC
+                    ${sql.identifier([this._table, query.sort])} ${query.order}
                 LIMIT
                     ${query.limit}
                 OFFSET

--- a/api/schema/req.query.ListBaseMaps.json
+++ b/api/schema/req.query.ListBaseMaps.json
@@ -8,6 +8,27 @@
         "page": {
             "$ref": "./util/page.json"
         },
+        "order": {
+            "$ref": "./util/order.json"
+        },
+        "sort": {
+            "type": "string",
+            "default": "created",
+            "enum": [
+                "id",
+                "created",
+                "updated",
+                "name",
+                "url",
+                "bounds",
+                "center",
+                "minzoom",
+                "maxzoom",
+                "format"
+            ],
+            "description": "Field to sort order by"
+        },
+
         "filter": {
             "type": "string",
             "default": "",

--- a/api/web/src/components/BaseMap/Location.vue
+++ b/api/web/src/components/BaseMap/Location.vue
@@ -31,6 +31,8 @@ export default {
     },
     methods: {
         mountMap: function() {
+            const url = String(window.stdurl(`/api/basemap/${this.basemap.id}/tiles/`)) + `{z}/{x}/{y}?token=${localStorage.token}`;
+
             const tmpmap = new mapgl.Map({
                 container: this.$refs.map,
                 zoom: 0,
@@ -41,12 +43,7 @@ export default {
                         basemap: {
                             type: 'raster',
                             tileSize: 256,
-                            tiles: [
-                                this.basemap.url
-                                    .replace('{$z}', '{z}')
-                                    .replace('{$x}', '{x}')
-                                    .replace('{$y}', '{y}')
-                            ]
+                            tiles: [ url ]
                         }
                     },
                     layers: [{

--- a/api/web/src/components/Data/Location.vue
+++ b/api/web/src/components/Data/Location.vue
@@ -76,18 +76,14 @@ export default {
     },
     methods: {
         basemap: async function() {
-            const list = await window.std('/api/basemap?limit=1');
+            const list = await window.std('/api/basemap?limit=1&order=asc&sort=created');
             if (list.basemaps.length) {
+                const url = String(window.stdurl(`/api/basemap/${list.basemaps[0].id}/tiles/`)) + `{z}/{x}/{y}?token=${localStorage.token}`;
                 this.style.sources = {
                     basemap: {
                         type: 'raster',
                         tileSize: 256,
-                        tiles: [
-                            list.basemaps[0].url
-                                .replace('{$z}', '{z}')
-                                .replace('{$x}', '{x}')
-                                .replace('{$y}', '{y}')
-                        ]
+                        tiles: [ url ]
                     }
                 }
 


### PR DESCRIPTION
### Context

While importing the All The Maps Topo layer many of the sources failed to display in the UI. Upon further digging this is due to one of two reasons

- HTTP tile source resulting in an mixed content warning when used by the HTTPS UI
- CORS issue in that the layer does not have wildcard cors headers

### Action
- Add `order` param to BaseMap API
- Add `sort` param to BaseMap API
- Add Proxy Implementation to avoid CORS issue